### PR TITLE
PNG render method's $saveandprint param was forced to false when passed to QRencode

### DIFF
--- a/lib/PHPQRCode/QRcode.php
+++ b/lib/PHPQRCode/QRcode.php
@@ -139,7 +139,7 @@ class QRcode {
     public static function png($text, $outfile = false, $level = Constants::QR_ECLEVEL_L, $size = 3, $margin = 4, $saveandprint=false)
     {
         $enc = QRencode::factory($level, $size, $margin);
-        return $enc->encodePNG($text, $outfile, $saveandprint=false);
+        return $enc->encodePNG($text, $outfile, $saveandprint);
     }
 
     //----------------------------------------------------------------------


### PR DESCRIPTION
I was trying to render a QRcode in PNG to browser AND storing for cache matter

``` php
$qrCodeFile = 'cache/'.md5($val).'.png';
if (file_exists($qrCodeFile)) {
    header('Content-type: image/png');
    readfile($qrCodeFile);
    exit;
} else {
    QRcode::png($val, $qrCodeFile, Constants::QR_ECLEVEL_L, 3, 1, true);
}
```

And realized that the QRcode wasn't rendered on browser on first run (file was correctly saved though).

The issue resides in `QRcode::png()` where `QRencode::encodePNG()` last parameter (`$saveandprint`) is forced to `bool(false)` whatever the `QRcode::png()`'s `$saveandprint` value is.
