### PR TITLE
Exposing the PHP image resource and removed GLOBALS variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+/nbproject/private/

--- a/lib/PHPQRCode/QRcode.php
+++ b/lib/PHPQRCode/QRcode.php
@@ -138,11 +138,43 @@ class QRcode {
     //----------------------------------------------------------------------
     public static function png($text, $outfile = false, $level = Constants::QR_ECLEVEL_L, $size = 3, $margin = 4, $saveandprint=false)
     {
-        $enc = QRencode::factory($level, $size, $margin);
-        return $enc->encodePNG($text, $outfile, $saveandprint);
+        $image = self::image($text, $outfile, $level, $size, $margin);
+		
+		if ($image == null) {
+			return null;
+		}
+		
+        if ($outfile === false) {
+            Header("Content-type: image/png");
+            ImagePng($outfile);
+        } else {
+            if($saveandprint===TRUE){
+                ImagePng($image, $outfile);
+                header("Content-type: image/png");
+                ImagePng($image);
+            }else{
+                ImagePng($image, $outfile);
+            }
+        }
+
+        ImageDestroy($image);
     }
 
-    //----------------------------------------------------------------------
+	public static function jpg($text, $outfile = false, $level = Constants::QR_ECLEVEL_L, $size = 3, $margin = 4, $quality = 85)
+	{
+        $image = self::image($text, $outfile, $level, $size, $margin);
+		
+        if ($outfile === false) {
+            Header("Content-type: image/jpeg");
+            ImageJpeg($image, null, $quality);
+        } else {
+            ImageJpeg($image, $outfile, $quality);
+        }
+
+        ImageDestroy($image);
+	}
+
+	//----------------------------------------------------------------------
     public static function text($text, $outfile = false, $level = Constants::QR_ECLEVEL_L, $size = 3, $margin = 4)
     {
         $enc = QRencode::factory($level, $size, $margin);
@@ -154,5 +186,12 @@ class QRcode {
     {
         $enc = QRencode::factory($level, $size, $margin);
         return $enc->encodeRAW($text, $outfile);
+    }
+
+	//----------------------------------------------------------------------
+    public static function image($text, $outfile = false, $level = Constants::QR_ECLEVEL_L, $size = 3, $margin = 4)
+    {
+        $enc = QRencode::factory($level, $size, $margin);
+        return $enc->encodeImage($text, $outfile);
     }
 }

--- a/lib/PHPQRCode/QRencode.php
+++ b/lib/PHPQRCode/QRencode.php
@@ -113,7 +113,7 @@ class QRencode {
     }
 
     //----------------------------------------------------------------------
-    public function encodePNG($intext, $outfile = false,$saveandprint=false)
+    public function encodeImage($intext, $outfile = false)
     {
         try {
             ob_start();
@@ -126,12 +126,12 @@ class QRencode {
 
             $maxSize = (int)(Constants::QR_PNG_MAXIMUM_SIZE / (count($tab)+2*$this->margin));
 
-            QRimage::png($tab, $outfile, min(max(1, $this->size), $maxSize), $this->margin,$saveandprint);
-        } catch (Exception $e) {
-            echo $e->getMessage();
-            die();
+	        $image = QRimage::image($tab,  min(max(1, $this->size), $maxSize), $this->margin);
 
+            return $image;
+        } catch (Exception $e) {
             QRtools::log($outfile, $e->getMessage());
         }
     }
+
 }

--- a/lib/PHPQRCode/QRimage.php
+++ b/lib/PHPQRCode/QRimage.php
@@ -27,42 +27,6 @@ namespace PHPQRCode;
 class QRimage {
 
     //----------------------------------------------------------------------
-    public static function png($frame, $filename = false, $pixelPerPoint = 4, $outerFrame = 4,$saveandprint=FALSE)
-    {
-        $image = self::image($frame, $pixelPerPoint, $outerFrame);
-
-        if ($filename === false) {
-            Header("Content-type: image/png");
-            ImagePng($image);
-        } else {
-            if($saveandprint===TRUE){
-                ImagePng($image, $filename);
-                header("Content-type: image/png");
-                ImagePng($image);
-            }else{
-                ImagePng($image, $filename);
-            }
-        }
-
-        ImageDestroy($image);
-    }
-
-    //----------------------------------------------------------------------
-    public static function jpg($frame, $filename = false, $pixelPerPoint = 8, $outerFrame = 4, $q = 85)
-    {
-        $image = self::image($frame, $pixelPerPoint, $outerFrame);
-
-        if ($filename === false) {
-            Header("Content-type: image/jpeg");
-            ImageJpeg($image, null, $q);
-        } else {
-            ImageJpeg($image, $filename, $q);
-        }
-
-        ImageDestroy($image);
-    }
-
-    //----------------------------------------------------------------------
     public static function image($frame, $pixelPerPoint = 4, $outerFrame = 4)
     {
         $h = count($frame);

--- a/lib/PHPQRCode/QRtools.php
+++ b/lib/PHPQRCode/QRtools.php
@@ -87,7 +87,8 @@ class QRtools {
             $frame = QRspec::newFrame($a);
             if (Constants::QR_IMAGE) {
                 $fileName = Constants::QR_CACHE_DIR.'frame_'.$a.'.png';
-                QRimage::png(self::binarize($frame), $fileName, 1, 0);
+                $image = QRimage::image(self::binarize($frame), $fileName, 1, 0);
+                ImagePng($image, $filename);
             }
 
             $width = count($frame);

--- a/lib/PHPQRCode/QRtools.php
+++ b/lib/PHPQRCode/QRtools.php
@@ -26,6 +26,8 @@ namespace PHPQRCode;
 
 class QRtools {
 
+	protected static $qr_time_bench = array();
+	
     //----------------------------------------------------------------------
     public static function binarize($frame)
     {
@@ -131,10 +133,7 @@ class QRtools {
         list($usec, $sec) = explode(" ", microtime());
         $time = ((float)$usec + (float)$sec);
 
-        if (!isset($GLOBALS['qr_time_bench']))
-            $GLOBALS['qr_time_bench'] = array();
-
-        $GLOBALS['qr_time_bench'][$markerId] = $time;
+        QRtools::$qr_time_bench[$markerId] = $time;
     }
 
     //----------------------------------------------------------------------
@@ -150,7 +149,7 @@ class QRtools {
                 <thead><tr style="border-bottom:1px solid silver"><td colspan="2" style="text-align:center">BENCHMARK</td></tr></thead>
                 <tbody>';
 
-        foreach($GLOBALS['qr_time_bench'] as $markerId=>$thisTime) {
+        foreach(QRtools::$qr_time_bench as $markerId=>$thisTime) {
             if ($p > 0) {
                 echo '<tr><th style="text-align:right">till '.$markerId.': </th><td>'.number_format($thisTime-$lastTime, 6).'s</td></tr>';
             } else {

--- a/readme.md
+++ b/readme.md
@@ -21,7 +21,7 @@ Then run the command `composer update`.
 
 Sample code:
 
-    \PHPQRCode\QRcode::png("Test", "/tmp/qrcode.png", 'L', 4, 2);
+    \PHPQRCode\QRcode::png("Test", "/tmp/qrcode.png", Constants::QR_ECLEVEL_L, 4, 2);
 
 This code will generate a PNG file on '/tmp/qrcode.png' with a QRCode that contains the word 'Test'.
 


### PR DESCRIPTION
Hi, 

I needed to process the generated QR image before send it to the user but the existing QRcode class did not exposed the image object. The current method QRimage::PNG also output HTTP headers and destroy the image resource. 

So, I modified this behavior to make it simpler and I did maintain the previous existing features. 

I also removed the $GLOBALS variable;

To test if everything is working just run the code below:

``` php
use PHPQRCode\Constants;
use PHPQRCode\QRcode;
use PHPQRCode\QRtools;

// Existing feature
QRcode::png("Test", "/tmp/qrcode.png", Constants::QR_ECLEVEL_L, 4, 2);

// New feature (was in QRimage, but the feature works like the QRcode::png)
QRcode::jpg("Test", "/tmp/qrcode.jpg", Constants::QR_ECLEVEL_L, 4, 2);

// New feature
$image = QRcode::image("Test", false, Constants::QR_ECLEVEL_L, 4, 2);
imagepng($image, '/tmp/qrcode2.png');

// Just for test the $GLOBALS 
QRtools::timeBenchmark();
```
